### PR TITLE
Add scheduled RDK dependency bump via shared workflow

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -1,45 +1,14 @@
 name: Bump Versions
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
   schedule:
-    - cron: '30 17 * * WED' # 12:30 EST on wednesdays
+    - cron: '30 17 * * WED' # 12:30 EST on Wednesdays
   workflow_dispatch:
 
 jobs:
   bump-versions:
-    name: Bump Package Versions
-    if: github.repository_owner == 'viam-modules'
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/viamrobotics/rdk-devenv:amd64
-    timeout-minutes: 10
-
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Update go dependencies
-      id: gobump
-      run: |
-        sudo chown -R testbot .
-        sudo -u testbot bash -lc 'go get go.viam.com/rdk'
-        sudo -u testbot bash -lc 'go get go.viam.com/api'
-        sudo -u testbot bash -lc 'go mod tidy'
-        GEN_DIFF=$(git status -s)
-        
-        if [ -n "$GEN_DIFF" ]; then
-            echo "needs_pr=1" >> $GITHUB_OUTPUT
-        fi
-    - name: Add + Commit + Open PR
-      if: steps.gobump.outputs.needs_pr == 1
-      uses: peter-evans/create-pull-request@v5
-      with:
-          commit-message: '[WORKFLOW] Updating go dependencies'
-          branch: 'workflow/update-dependencies'
-          delete-branch: true
-          base: main
-          title: Automated Go Dependencies Update
-          body: This is an auto-generated PR to update go dependencies. Please confirm tests are passing before merging.
+    uses: viam-modules/common-workflows/.github/workflows/bump_go_dependencies.yaml@main


### PR DESCRIPTION
Adds a weekly (Wednesday 12:30 EST, plus manual `workflow_dispatch`) job that bumps `go.viam.com/rdk` and `go.viam.com/api` — and only those plus their required transitive minimums, not all dependencies — then opens a PR if anything changed.

This **replaces the inline copy** of the bump job with a call to the shared reusable workflow — same behavior, same weekly Wednesday schedule, one place to maintain the logic going forward.

⚠️ **Depends on viam-modules/common-workflows#23** — that PR adds the reusable workflow this references at `@main`. Merge it first, or the next scheduled run here will fail with workflow-not-found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)